### PR TITLE
1) fix on timestamps for $addToSet-$each for when the timestamp are i…

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ Here is a list of available processors:
 
 ### MongoDB
 
-* AddToArrayMongo - Allows you to add elements in an array of a document
+* PartialUpdateMongo - Allows you to use $set, $addToSet-$each for adding elements in arrays, $currentDate, and $inc. Additionally, you can reference a parent-child relationship now with dot notation as in parent.child for $set and $addToSet. You can use this one one child dimension only for now w/ dot notation.
 * PutMongoWithDuplicationCheck - Extends the PutMongo Processor and adds a new "already-exists" relationship if the document with the same key already exists in mongo
 
 ### JSON
 
-* BetterAttributesToJSON - We took some of the original goals that we thought the provided AttributesToJSON should have and added to those by allowing you to more exactly specify whether the attribute in ouputted-JSON format should be a String, Integer, Double, or Date. The current existing AttributesToJSON processor falls well below the needs we have by only outputing things in String form. You simply list the FlowFile expression variables in the corresponding String, Integer, Double, and Date lists and let this processor do the rest.  Dates are expected in Epoch long form down to the millisecond.  A Boolean when listed in the String list will automatically be converted to a Boolean in the output.
+* BetterAttributesToJSON - We took some of the original goals that we thought the provided AttributesToJSON should have and added to those by allowing you to more exactly specify whether the attribute in outputted-JSON format should be a String, Integer, Double, or Date. The current existing AttributesToJSON processor falls well below the needs we have by only outputing things in String form. You simply list the FlowFile expression variables in the corresponding String, Integer, Double, and Date lists and let this processor do the rest.  Dates are expected in Epoch long form down to the millisecond.  A Boolean when listed in the String list will automatically be converted to a Boolean in the output.
 * ConvertSecurityMarkingAndAttrListIntoJson - This will take in a raw security marking from a file along with lists of other flow attributes.  The raw security marking will be converted into a Classification JSON object.  The other flow attributes will be included in the JSON conversion.
 
 ### Sockets


### PR DESCRIPTION
…n inside the array within an array that holds objects and not just simple strings or numbers; 2) adjustment on $addToSet-$each for when there is a parent.child array and we need $addToSet-$each.  Introducing parent.child dot notation for being able to do that w/ PartialUpdateMongo. 3) adjustment on $set for when there is a parent.child -- either array or non-array.  Introducing parent.child dot notation here as well. These two should go hand-in-hand and be provided at the same time.