### PR TITLE
Upgrade socket.io client to v2.0.1

### DIFF
--- a/aces-nifi-processors/pom.xml
+++ b/aces-nifi-processors/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>io.socket</groupId>
             <artifactId>socket.io-client</artifactId>
-            <version>0.8.3</version>
+            <version>2.0.1</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
This is an upgrade to the socket.io Java client to v2.0.1 (latest), which will allow the client to communicate with socket.io v3 and v4 servers. This is breaking change as the v2 Java client is not compatible with v1 or v2 socket.io Java servers (https://github.com/socketio/socket.io-client-java). 
This processor was tested with socket.io Java server v3.0.2 with HTTP, HTTPS, and websocket transport. 
The 'connecting' and 'reconnect_attempt' events were deprecated and removed.